### PR TITLE
ci: upgrade upload-sarif action to v4 for consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           soft_fail: false
 
       - name: Upload IaC scan results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: checkov.sarif


### PR DESCRIPTION
Upgrades the \github/codeql-action/upload-sarif\ action in the iac-scan job from v3 to v4 to match the security-scan and build jobs.\n\nFixes #13