### PR TITLE
fix: set MAX_CONTENT_LENGTH to 1 MB to prevent request body DoS

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1)
 
 


### PR DESCRIPTION
Sets Flask \MAX_CONTENT_LENGTH\ to 1 MB so the application rejects oversized request bodies and is no longer vulnerable to memory-exhaustion DoS.\n\nFixes #12