### PR TITLE
fix: add common secret file patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,13 @@ Thumbs.db
 
 # Scan reports
 *.sarif
+
+# Secrets
+.env
+.env.local
+.env.*.local
+*.pem
+*.key
+*.p12
+*.pfx
+secrets/


### PR DESCRIPTION
Adds common secret and credential file patterns (.env, *.pem, *.key, etc.) to .gitignore to reduce the risk of accidentally committing sensitive data.\n\nFixes #10