### PR TITLE
ci: add id-token: write permission for AWS OIDC authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   security-events: write
+  id-token: write
 
 env:
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Adds id-token: write to the workflow permissions block so deploy jobs can authenticate with AWS via OIDC.

Fixes #4