### PR TITLE
fix: add /tmp mount to ECS task definition for read-only root filesystem

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -101,7 +101,17 @@ resource "aws_ecs_task_definition" "this" {
 
     readonlyRootFilesystem = true
     essential              = true
+
+    mountPoints = [{
+      sourceVolume  = "tmp"
+      containerPath = "/tmp"
+      readOnly      = false
+    }]
   }])
+
+  volume {
+    name = "tmp"
+  }
 
   tags = var.tags
 }


### PR DESCRIPTION
Adds an ephemeral tmp volume and mountPoint at /tmp to prevent gunicorn from crashing when readonlyRootFilesystem is enabled.

Fixes #7