### PR TITLE
fix: remove S3 bucket self-logging to prevent infinite log loop

### DIFF
--- a/terraform/modules/alb/main.tf
+++ b/terraform/modules/alb/main.tf
@@ -153,11 +153,6 @@ resource "aws_s3_bucket_versioning" "alb_logs" {
   }
 }
 
-resource "aws_s3_bucket_logging" "alb_logs" {
-  bucket        = aws_s3_bucket.alb_logs.id
-  target_bucket = aws_s3_bucket.alb_logs.id
-  target_prefix = "access-logs/"
-}
 
 resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
   bucket = aws_s3_bucket.alb_logs.id


### PR DESCRIPTION
Removes the aws_s3_bucket_logging resource that caused the ALB logs bucket to log access to itself, creating an infinite loop of ever-growing log objects.

Fixes #6