### PR TITLE
fix: add ELB log delivery bucket policy with configurable account ID

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -45,6 +45,12 @@ variable "certificate_arn" {
   description = "ACM certificate ARN for HTTPS"
 }
 
+variable "elb_account_id" {
+  type        = string
+  default     = ""
+  description = "AWS ELB account ID for ALB access logs bucket policy"
+}
+
 variable "container_image" {
   type        = string
   description = "Docker image URI (ECR or other registry)"
@@ -68,6 +74,7 @@ module "alb" {
   vpc_id            = module.vpc.vpc_id
   public_subnet_ids = module.vpc.public_subnet_ids
   certificate_arn   = var.certificate_arn
+  elb_account_id    = var.elb_account_id
 }
 
 module "ecs" {

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -45,6 +45,12 @@ variable "certificate_arn" {
   description = "ACM certificate ARN for HTTPS"
 }
 
+variable "elb_account_id" {
+  type        = string
+  default     = ""
+  description = "AWS ELB account ID for ALB access logs bucket policy"
+}
+
 variable "container_image" {
   type        = string
   description = "Docker image URI (ECR or other registry)"
@@ -68,6 +74,7 @@ module "alb" {
   vpc_id            = module.vpc.vpc_id
   public_subnet_ids = module.vpc.public_subnet_ids
   certificate_arn   = var.certificate_arn
+  elb_account_id    = var.elb_account_id
 }
 
 module "ecs" {

--- a/terraform/modules/alb/main.tf
+++ b/terraform/modules/alb/main.tf
@@ -25,6 +25,12 @@ variable "allowed_cidr_blocks" {
   description = "CIDR blocks allowed to reach the ALB. Restrict in production."
 }
 
+variable "elb_account_id" {
+  type        = string
+  default     = ""
+  description = "AWS ELB account ID for the target region (required for ALB access logs)"
+}
+
 variable "waf_acl_arn" {
   type        = string
   default     = ""
@@ -195,6 +201,23 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "alb_logs" {
       sse_algorithm = "aws:kms"
     }
   }
+}
+
+
+resource "aws_s3_bucket_policy" "alb_logs" {
+  count  = var.elb_account_id != "" ? 1 : 0
+  bucket = aws_s3_bucket.alb_logs.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        AWS = "arn:aws:iam::${var.elb_account_id}:root"
+      }
+      Action   = "s3:PutObject"
+      Resource = "${aws_s3_bucket.alb_logs.arn}/alb/*"
+    }]
+  })
 }
 
 resource "aws_s3_bucket_public_access_block" "alb_logs" {


### PR DESCRIPTION
Adds an aws_s3_bucket_policy resource to the ALB logs bucket that grants the ELB service principal permission to write access logs. The ELB account ID is exposed as a new elb_account_id variable so callers can provide the region-specific value.

Also updates terraform/environments/dev and prod to pass the new variable.

Fixes #8