### PR TITLE
fix: update ECS task definition on deploy so new images are rolled out

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,16 +24,33 @@ case "$ENVIRONMENT" in
         CLUSTER="${APP_NAME:-secure-pipeline}-${ENVIRONMENT}"
         SERVICE="${APP_NAME:-secure-pipeline}-${ENVIRONMENT}"
         ECR_REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${APP_NAME:-secure-pipeline}"
+        LOCAL_IMAGE="${IMAGE_NAME:-secure-pipeline-template}:${IMAGE_TAG}"
 
         aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$ECR_REPO"
 
-        docker tag "$IMAGE_TAG" "$ECR_REPO:$IMAGE_TAG"
+        docker tag "$LOCAL_IMAGE" "$ECR_REPO:$IMAGE_TAG"
         docker push "$ECR_REPO:$IMAGE_TAG"
+
+        TASK_DEF=$(aws ecs describe-task-definition \
+            --task-definition "${APP_NAME:-secure-pipeline}-${ENVIRONMENT}" \
+            --region "$AWS_REGION" \
+            --query 'taskDefinition' \
+            --output json)
+
+        NEW_TASK_DEF=$(echo "$TASK_DEF" | jq \
+            --arg IMAGE "$ECR_REPO:$IMAGE_TAG" \
+            '.containerDefinitions[0].image = $IMAGE | del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)')
+
+        NEW_REVISION=$(aws ecs register-task-definition \
+            --cli-input-json "$NEW_TASK_DEF" \
+            --region "$AWS_REGION" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
 
         aws ecs update-service \
             --cluster "$CLUSTER" \
             --service "$SERVICE" \
-            --force-new-deployment \
+            --task-definition "$NEW_REVISION" \
             --region "$AWS_REGION"
 
         echo "Deployment triggered. Waiting for stabilization..."


### PR DESCRIPTION
Updates deploy.sh to register a new ECS task definition revision with the pushed image URI, then updates the service to use that revision. Previously, --force-new-deployment only restarted tasks using the existing task definition, so new images were never deployed.

Also builds the full local image name internally using IMAGE_NAME (default: secure-pipeline-template) so the script works when called with only a tag/SHA.

Fixes #5