### PR TITLE
docs: rename CLAUDE.md to AGENTS.md and adopt trunk-based workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,9 @@ Reusable CI/CD pipeline template with integrated security scanning. Designed to 
 - **Policies as code**: OPA/Rego in `policies/`
 
 ## Git workflow
-- **Gitflow**: `main` (stable releases), `develop` (active development)
-- Feature branches: `feature/<name>` off `develop`
+- **Trunk-based**: `main` is the single source of truth
+- Feature branches: short-lived branches off `main`, merged via PR
+- PRs target `main` directly
 - Commits: human style, no AI attribution, no co-authored-by tags
 - Author: Adur <26388026+adurrr@users.noreply.github.com>
 


### PR DESCRIPTION
Renames CLAUDE.md to AGENTS.md and updates the git workflow section from Gitflow to trunk-based development.\n\nChanges:\n- Single main branch as the source of truth\n- Short-lived feature branches off main\n- PRs target main directly\n- Removed develop branch references