### PR TITLE
fix: add DNS egress rules to ECS security group

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -164,6 +164,22 @@ resource "aws_security_group" "ecs" {
     description = "HTTPS outbound for pulling images and API calls"
   }
 
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "DNS outbound for name resolution"
+  }
+
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "DNS outbound (TCP fallback) for name resolution"
+  }
+
   tags = merge(var.tags, { Name = "${var.name}-ecs" })
 
   lifecycle {


### PR DESCRIPTION
## Summary
ECS Fargate tasks need DNS resolution to function properly - resolving service endpoints, pulling container images from registries, and communicating with AWS services. Without DNS egress rules, tasks may fail to resolve endpoints.

This fix adds UDP and TCP port 53 egress rules to the ECS security group to allow DNS resolution.

## Changes
- Added UDP port 53 egress rule for standard DNS queries
- Added TCP port 53 egress rule as a fallback for larger DNS responses