### PR TITLE
fix: add .dockerignore to exclude unnecessary files from Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,55 @@
+# Git
+.git
+.gitignore
+
+# CI/CD
+.github/
+
+# Terraform state and modules
+terraform/
+
+# Security scan configs (not needed in image)
+.checkov.yml
+.semgrep.yml
+
+# Policies (not needed in image)
+policies/
+
+# Scripts (not needed in image)
+scripts/
+
+# Docker compose (not needed in image)
+docker-compose.yml
+
+# Certs (generated locally, never in image)
+docker/certs/
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Python cache
+__pycache__/
+*.pyc
+.venv/
+
+# Scan reports
+*.sarif
+
+# Secrets
+.env
+.env.local
+.env.*.local
+*.pem
+*.key
+*.p12
+*.pfx
+
+# Documentation
+*.md
+LICENSE
+AGENTS.md


### PR DESCRIPTION
## Summary
- Adds `.dockerignore` file to exclude unnecessary files from Docker build context
- Reduces Docker image build time by minimizing context size
- Prevents potential sensitive data leaks (secrets, .env files, keys) from being included in image

## Security Benefits
- Excludes `.env`, `*.pem`, `*.key`, `*.pfx` files that may contain secrets
- Excludes `.git` directory to prevent repository metadata in image
- Excludes scan reports (`*.sarif`) that may contain vulnerability details

## Build Performance Benefits
- Reduces build context size significantly
- Faster image builds and pushes
- Smaller image layers

## Files Excluded
- Git metadata (`.git/`)
- CI/CD configs (`.github/`)
- Terraform files (`terraform/`)
- Security configs (`.checkov.yml`, `.semgrep.yml`)
- Policies and scripts (not needed in runtime)
- IDE and OS files
- Python cache
- Documentation files