### PR TITLE
fix: use Terraform plan JSON for Conftest policy checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: dummy
           AWS_REGION: us-east-1
         run: |
+          cat > provider_override.tf << 'EOF'
+          provider "aws" {
+            skip_credentials_validation = true
+            skip_requesting_account_id  = true
+            skip_metadata_api_check     = true
+          }
+          EOF
           terraform init -backend=false
           terraform plan -no-color -out=tfplan \
             -var="certificate_arn=arn:aws:acm:us-east-1:123456789012:certificate/dummy" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,10 @@ jobs:
 
       - name: Generate Terraform plan JSON
         working-directory: terraform/environments/dev
+        env:
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
+          AWS_REGION: us-east-1
         run: |
           terraform init -backend=false
           terraform plan -no-color -out=tfplan \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,8 +164,15 @@ jobs:
       - name: Check Dockerfile policies
         run: conftest test docker/Dockerfile -p policies/conftest/
 
+      - name: Generate Terraform plan JSON
+        working-directory: terraform/environments/dev
+        run: |
+          terraform init -backend=false
+          terraform plan -no-color -out=tfplan
+          terraform show -json tfplan > ../../tfplan.json
+
       - name: Check Terraform policies
-        run: conftest test terraform/ -p policies/opa/ --all-namespaces
+        run: conftest test tfplan.json -p policies/opa/ --all-namespaces
 
   deploy-staging:
     if: github.ref == 'refs/heads/main' && vars.AWS_REGION != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,9 @@ jobs:
         working-directory: terraform/environments/dev
         run: |
           terraform init -backend=false
-          terraform plan -no-color -out=tfplan
+          terraform plan -no-color -out=tfplan \
+            -var="certificate_arn=arn:aws:acm:us-east-1:123456789012:certificate/dummy" \
+            -var="container_image=dummy-image:latest"
           terraform show -json tfplan > ../../tfplan.json
 
       - name: Check Terraform policies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
           terraform plan -no-color -out=tfplan \
             -var="certificate_arn=arn:aws:acm:us-east-1:123456789012:certificate/dummy" \
             -var="container_image=dummy-image:latest"
-          terraform show -json tfplan > ../../tfplan.json
+          terraform show -json tfplan > ../../../tfplan.json
 
       - name: Check Terraform policies
         run: conftest test tfplan.json -p policies/opa/ --all-namespaces

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.0"
+
       - name: Install Conftest
         run: |
           VERSION=0.68.2

--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -54,6 +54,11 @@ fi
 header "Policy check — Conftest"
 if check_tool conftest; then
     conftest test "$ROOT/docker/Dockerfile" -p "$ROOT/policies/conftest/" || FAILED=1
+
+    # Terraform policy testing requires a plan JSON:
+    #   cd terraform/environments/dev && terraform init -backend=false
+    #   terraform plan -out=tfplan && terraform show -json tfplan > tfplan.json
+    #   conftest test tfplan.json -p policies/opa/ --all-namespaces
 fi
 
 # --- Container image scan ---


### PR DESCRIPTION
## Summary
- Update `policy-check` job to generate a Terraform plan JSON before running Conftest
- Conftest expects JSON/YAML input, not raw `.tf` HCL files
- This ensures reliable policy checks for Terraform configurations

## Changes
- `.github/workflows/ci.yml`: Added `Generate Terraform plan JSON` step before Conftest test
- `scripts/scan.sh`: Added comment documenting the Terraform plan JSON workflow