### PR TITLE
fix: pass kms_key_arn and waf_acl_arn through to Terraform modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,15 @@ jobs:
       - name: Check Dockerfile policies
         run: conftest test docker/Dockerfile -p policies/conftest/
 
+      - name: Generate Terraform plan JSON
+        working-directory: terraform/environments/dev
+        run: |
+          terraform init -backend=false
+          terraform plan -no-color -out=tfplan
+          terraform show -json tfplan > ../../tfplan.json
+
       - name: Check Terraform policies
-        run: conftest test terraform/ -p policies/opa/ --all-namespaces
+        run: conftest test tfplan.json -p policies/opa/ --all-namespaces
 
   deploy-staging:
     if: github.ref == 'refs/heads/main' && vars.AWS_REGION != ''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,11 @@ services:
     depends_on:
       app:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "https://localhost:443/healthz", "--no-check-certificate"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
     restart: unless-stopped
     read_only: true
     security_opt:
@@ -43,3 +48,8 @@ services:
     tmpfs:
       - /var/cache/nginx
       - /var/run
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M

--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -54,6 +54,11 @@ fi
 header "Policy check — Conftest"
 if check_tool conftest; then
     conftest test "$ROOT/docker/Dockerfile" -p "$ROOT/policies/conftest/" || FAILED=1
+
+    # Terraform policy testing requires a plan JSON:
+    #   cd terraform/environments/dev && terraform init -backend=false
+    #   terraform plan -out=tfplan && terraform show -json tfplan > tfplan.json
+    #   conftest test tfplan.json -p policies/opa/ --all-namespaces
 fi
 
 # --- Container image scan ---


### PR DESCRIPTION
## Summary
- Add `kms_key_arn` and `waf_acl_arn` variables to both dev and prod environment Terraform configurations
- Pass these variables through to the VPC, ALB, and ECS modules

## Problem
Without these pass-throughs, two issues occur:
1. CloudWatch logs won't be encrypted with a customer-managed KMS key even when `kms_key_arn` is provided
2. WAF protection won't be applied to the ALB even when `waf_acl_arn` is provided

## Changes
- Added `kms_key_arn` variable to `terraform/environments/dev/main.tf` and `terraform/environments/prod/main.tf`
- Added `waf_acl_arn` variable to both environment configurations
- Updated VPC module to accept `kms_key_arn`
- Updated ALB module to accept `waf_acl_arn`
- Updated ECS module to accept `kms_key_arn`