### PR TITLE
fix: add health check and resource limits to nginx in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,11 @@ services:
     depends_on:
       app:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "https://localhost:443/healthz", "--no-check-certificate"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
     restart: unless-stopped
     read_only: true
     security_opt:
@@ -43,3 +48,8 @@ services:
     tmpfs:
       - /var/cache/nginx
       - /var/run
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M


### PR DESCRIPTION
## Summary
- Add health check and resource limits to nginx service in docker-compose.yml
- Brings nginx configuration in line with the app service which already has both

## Problem
The nginx service lacked health monitoring and resource constraints while the app service had both configured. This creates inconsistency and means:
1. Nginx could consume unbounded CPU/memory without limits
2. No automated health monitoring for the nginx service

## Solution
Added to nginx service:
- Health check using wget to spider the healthz endpoint (mirrors app service pattern)
- Resource limits: 0.25 CPU cores, 128MB memory (appropriate for reverse proxy)