### PR TITLE
fix: restrict ALB egress to VPC CIDR instead of 0.0.0.0/0

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -75,6 +75,7 @@ module "alb" {
   public_subnet_ids = module.vpc.public_subnet_ids
   certificate_arn   = var.certificate_arn
   elb_account_id    = var.elb_account_id
+  vpc_cidr          = "10.0.0.0/16"
 }
 
 module "ecs" {

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -75,6 +75,7 @@ module "alb" {
   public_subnet_ids = module.vpc.public_subnet_ids
   certificate_arn   = var.certificate_arn
   elb_account_id    = var.elb_account_id
+  vpc_cidr          = "10.1.0.0/16"
 }
 
 module "ecs" {

--- a/terraform/modules/alb/main.tf
+++ b/terraform/modules/alb/main.tf
@@ -42,6 +42,11 @@ variable "tags" {
   default = {}
 }
 
+variable "vpc_cidr" {
+  type        = string
+  description = "VPC CIDR block to restrict ALB egress to VPC scope"
+}
+
 resource "aws_lb" "this" {
   name               = var.name
   internal           = false
@@ -133,7 +138,7 @@ resource "aws_security_group" "alb" {
     from_port   = var.container_port
     to_port     = var.container_port
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.vpc_cidr]
     description = "To ECS tasks"
   }
 


### PR DESCRIPTION
## Summary
- Add `vpc_cidr` variable to ALB module to restrict egress traffic scope
- Replace hardcoded `0.0.0.0/0` in ALB egress rule with VPC CIDR reference
- Update dev (`10.0.0.0/16`) and prod (`10.1.0.0/16`) environments to pass VPC CIDR

## Security Improvement
The ALB security group egress rule previously allowed traffic to the entire internet (`0.0.0.0/0`). This change restricts egress to only the VPC CIDR range, following the principle of least privilege. The ALB only needs to communicate with ECS tasks within the VPC, so broader internet access is unnecessary and poses a security risk.